### PR TITLE
Run bin/buildout got warning

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,7 @@
 [buildout]
 newest = false
 
-extensions = buildout-versions
+show-picked-versions = true
 
 develop = .
 


### PR DESCRIPTION
While I build the project by ./bin/buildout, it will show the error as below.

> Error: The extension buildout-versions is now included in buildout itself.
> Remove the extension from your configuration and look at the `show-picked-versions`
> option in buildout's documentation.

I update the buildout.cfg as my commit.

Thanks!

FYI: https://pypi.python.org/pypi/zc.buildout/2.0.0
