### PR TITLE
Make it support non-English language (like Chinese)

### DIFF
--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -21,7 +21,7 @@ def _with_json(f):
     @wraps(f)
     def wrapper(self, json_string, *args, **kwargs):
         return json.dumps(
-            f(self, load_json(json_string), *args, **kwargs))
+            f(self, load_json(json_string), *args, **kwargs), ensure_ascii=False)
     return wrapper
 
 

--- a/tests/json.txt
+++ b/tests/json.txt
@@ -109,3 +109,7 @@ Stringify Complex Object
 
     Should Be Equal As Strings  ${json_string}   {"a": "1", "b": "12", "names": ["First Name", "Family Name", "Email"]}
 
+Get Json Value In Chinese OK
+    Set Test Variable  ${chinese}       "中"
+    ${result}=  Get Json Value  {"foo":${chinese}}   /foo
+    Should Be Equal    ${result}       ${chinese}


### PR DESCRIPTION
The "Get Json Value" api now will dump the Json part into a string. For English it's still no too inconvenient to check the value (just add the quote). But Chinese will be transformed into something like "\u8fcd". So make the dumps not ensure ascii.
