### PR TITLE
support bodies with unicode

### DIFF
--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -471,7 +471,7 @@ class HTTP:
         | ${body}=            | Get Response Body |                                      |
         | Should Start With   | ${body}           | <?xml version="1.0" encoding="UTF-8" |
         """
-        return self.response.body
+        return self.response.body.decode("utf-8")
 
     def response_body_should_contain(self, should_contain):
         """

--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -483,11 +483,11 @@ class HTTP:
         | Response Body Should Contain | encoding="UTF-8" |
         """
         logger.debug('Testing whether "%s" contains "%s".' % (
-            self.response.body, should_contain))
+            self.get_response_body(), should_contain))
 
-        assert should_contain in self.response.body, \
+        assert should_contain in self.get_response_body(), \
             '"%s" should have contained "%s", but did not.' % (
-                self.response.body, should_contain)
+                self.get_response_body(), should_contain)
 
     def log_response_body(self, log_level='INFO'):
         """
@@ -495,9 +495,9 @@ class HTTP:
 
         Specify `log_level` (default: "INFO") to set the log level.
         """
-        if self.response.body:
+        if self.get_response_body():
             logger.write("Response body:", log_level)
-            logger.write(self.response.body, log_level)
+            logger.write(self.get_response_body(), log_level)
         else:
             logger.debug("No response body received", log_level)
 

--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -431,7 +431,7 @@ class HTTP:
         """
         logger.info(
             'Set request header "%s" to "%s"' % (header_name, header_value))
-        self.context.request_headers[header_name] = header_value
+        self.context.request_headers[str(header_name)] = header_value
 
     def set_basic_auth(self, username, password):
         """

--- a/tests/http/simple.txt
+++ b/tests/http/simple.txt
@@ -168,6 +168,14 @@ POST with one word request body
     POST                          /echo
     Response Body Should Contain  Tooot
 
+POST with Unicode request body
+    [Documentation]     Unicode in response body must not break 'should contain'
+    [Tags]  unicode
+    Set Request Body              Tschüss Süße
+    Set Request Header            Content-Type    text/plain
+    POST                          /echo
+    Response Body Should Contain  Tschüss Süße
+
 PUT with two word request body
     Set Request Body              Tooot Tooooot
     Set Request Header            Content-Type    text/plain

--- a/tests/http/simple.txt
+++ b/tests/http/simple.txt
@@ -176,6 +176,15 @@ POST with Unicode request body
     POST                          /echo
     Response Body Should Contain  Tschüss Süße
 
+POST with Unicode request body and Accept Header
+    [Documentation]     Request body and headers must allow to be concatenated
+    [Tags]  unicode
+    Set Request Body              Tschüss Süße
+    Set Request Header            Accept          application/json
+    Set Request Header            Content-Type    text/plain
+    POST                          /echo
+    Response Body Should Contain  Tschüss Süße
+
 PUT with two word request body
     Set Request Body              Tooot Tooooot
     Set Request Header            Content-Type    text/plain


### PR DESCRIPTION
Hi @peritus,

please consider these fixes regarding Unicode in request/response bodies for merging.
It seems likely that this PR fixes the issues mentioned by @jinlxz in https://github.com/peritus/robotframework-httplibrary/pull/18#issuecomment-65240835.

Btw, while debugging this I found that the special treatment regarding 'Content-Type' originally
added in 7cf67c8da20c6d28d1fe5cdb0589f07748a83743 for POST and in 04c955238633625ffb784ae19769df5ebd516104 for PUT may have become superfluous.

Thanks
Oliver
