### PR TITLE
Support python3

### DIFF
--- a/src/HttpLibrary/__init__.py
+++ b/src/HttpLibrary/__init__.py
@@ -2,9 +2,12 @@ from robot.api import logger
 
 from base64 import b64encode
 from functools import wraps
-from urlparse import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
-import livetest
+from . import livetest
 import json
 import jsonpointer
 import jsonpatch
@@ -13,7 +16,7 @@ import jsonpatch
 def load_json(json_string):
     try:
         return json.loads(json_string)
-    except ValueError, e:
+    except ValueError as e:
         raise ValueError("Could not parse '%s' as JSON: %s" % (json_string, e))
 
 
@@ -64,9 +67,10 @@ class HTTP:
             self.post_process_request(None)
 
         def pre_process_request(self):
-            if len(self.request_headers.items()) > 0:
+            request_header_items = list(self.request_headers.items())
+            if len(request_header_items) > 0:
                 logger.debug("Request headers:")
-                for name, value in self.request_headers.items():
+                for name, value in request_header_items:
                     logger.debug("%s: %s" % (name, value))
             else:
                 logger.debug("No request headers set")
@@ -417,7 +421,7 @@ class HTTP:
         Specify `log_level` (default: "INFO") to set the log level.
         """
         logger.write("Response headers:", log_level)
-        for name, value in self.response.headers.items():
+        for name, value in list(self.response.headers.items()):
             logger.write("%s: %s" % (name, value), log_level)
 
     # request headers
@@ -548,7 +552,7 @@ class HTTP:
 
         try:
             return json.dumps(data, ensure_ascii=False)
-        except ValueError, e:
+        except ValueError as e:
             raise ValueError(
                 "Could not stringify '%r' to JSON: %s" % (data, e))
 

--- a/src/HttpLibrary/livetest.py
+++ b/src/HttpLibrary/livetest.py
@@ -40,9 +40,18 @@ __version__ = '0.5'
 
 import sys
 import webtest
-import httplib
-import urlparse
-from Cookie import BaseCookie, CookieError
+try:
+    import httplib
+except ImportError:
+    import http.client as httplib
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+try:
+    from Cookie import BaseCookie, CookieError
+except ImportError:
+    from http.cookies import BaseCookie, CookieError
 from six.moves import http_cookiejar
 
 conn_classes = {'http': httplib.HTTPConnection,
@@ -118,7 +127,7 @@ class TestApp(webtest.TestApp):
 
     def _do_httplib_request(self, req):
         "Convert WebOb Request to httplib request."
-        headers = dict((name, val) for name, val in req.headers.iteritems())
+        headers = dict((name, val) for name, val in req.headers.items())
         if req.scheme not in self.conn:
             self._load_conn(req.scheme)
 
@@ -130,7 +139,7 @@ class TestApp(webtest.TestApp):
         res.status = '%s %s' % (webresp.status, webresp.reason)
         res.body = webresp.read()
         response_headers = []
-        for headername in dict(webresp.getheaders()).keys():
+        for headername in list(dict(webresp.getheaders()).keys()):
             for headervalue in webresp.msg.getheaders(headername):
                 response_headers.append((headername, headervalue))
         res.headerlist = response_headers
@@ -145,9 +154,9 @@ class TestApp(webtest.TestApp):
         headers = {}
         if self.cookies:
             c = BaseCookie()
-            for name, value in self.cookies.items():
+            for name, value in list(self.cookies.items()):
                 c[name] = value
-            hc = '; '.join(['='.join([m.key, m.value]) for m in c.values()])
+            hc = '; '.join(['='.join([m.key, m.value]) for m in list(c.values())])
             req.headers['Cookie'] = hc
 
         res = self._do_httplib_request(req)

--- a/src/rf_httplib_dev_helper.py
+++ b/src/rf_httplib_dev_helper.py
@@ -8,7 +8,7 @@ def run_cli(args):
     import robot
     try:
         robot.run_cli(args)
-    except Exception, e:
-        print e
+    except Exception as e:
+        print(e)
         import robot.runner
         robot.run_from_cli(args, robot.runner.__doc__)


### PR DESCRIPTION
This PR adds python3 support.  2to3 was used for the conversions.  It will try using the python2 packages before attempting python3.

I actually couldn't get the bootstrap.py file to work, and therefore test the changes.  It looks like that is heavily outdated compared to the [one I found](https://bootstrap.pypa.io/bootstrap-buildout.py) which seems to work with python3.  Even then, using the updated version, some things just didn't install correctly.

Also, the bootstrap.py file points at http://python-distribute.org/distribute_setup.py by default, which no longer exists.  That would explain why all the builds are failing.
